### PR TITLE
Use div macros for header/footer inclusion

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -19,7 +19,6 @@ begin
 require 'config/initializers/session_store.rb'
 rescue LoadError
 end
-require 'redmine/wiki_formatting/textile/redcloth3'
 
 require_dependency 'wiki_extensions_notifiable_patch'
 Dir::foreach(File.join(File.dirname(__FILE__), 'lib')) do |file|
@@ -89,8 +88,6 @@ Redmine::Plugin.register :redmine_wiki_extensions do
     :caption => Proc.new{|proj| WikiExtensionsMenu.title(proj.id, no)},
     :if => Proc.new{|proj| WikiExtensionsMenu.enabled?(proj.id, no)}
   }
-
-  RedCloth3::ALLOWED_TAGS << "div"
 
   activity_provider :wiki_comment, :class_name => 'WikiExtensionsComment', :default => false
 end

--- a/lib/wiki_extensions_wiki_controller_patch.rb
+++ b/lib/wiki_extensions_wiki_controller_patch.rb
@@ -89,10 +89,10 @@ module InstanceMethodsForWikiExtensionWikiController
     header = @wiki.find_page('Header')
     return unless header
     text = "\n"
-    text << '<div id="wiki_extentions_header">'
+    text << '<code></code>{{div_start_tag(wiki_extentions_header)}}'
     text << "\n\n"
     text << header.content.text
-    text << "\n\n</div>"
+    text << "\n\n<code></code>{{div_end_tag}}"
     text << "\n\n"
     text << @content.text
     @content.text = text
@@ -105,10 +105,10 @@ module InstanceMethodsForWikiExtensionWikiController
     return unless footer
     text = @content.text
     text << "\n"
-    text << '<div id="wiki_extentions_footer">'
+    text << '<code></code>{{div_start_tag(wiki_extentions_footer)}}'
     text << "\n\n"
     text << footer.content.text
-    text << "\n\n</div>"
+    text << "\n\n<code></code>{{div_end_tag}}"
 
   end
 end


### PR DESCRIPTION
In this changeset I removed `<div>` from allowed tags as it makes it
possible to post arbitrary `<div>` tags in journals with `@<div>@` markup.

It was originally put there to avoid issue with `<p>` tag wrapping of
included header/footer blocks by macros.

I found a workaround in current Textile parser which allows to disable
wrapping of macros. This can be done by adding `<code></code>` in the
beginning of the line. This way the rest of the line is rendered as is
without being put in a paragraph.

This behavior may change in RedCloth4, but Redmine is still not there so
we can use this workaround for a while, before Redmine comes up with an
appropriate way to disable paragraphs.

fixes https://github.com/haru/redmine_wiki_extensions/issues/8
related https://code.google.com/archive/p/redminewikiext/issues/4
related https://redmine.org/issues/29588
related https://redmine.org/issues/13695