### PR TITLE
prevent possible JS injection in foot note macro

### DIFF
--- a/lib/wiki_extensions_footnote.rb
+++ b/lib/wiki_extensions_footnote.rb
@@ -39,7 +39,7 @@ module WikiExtensionsFootnote
 
       o = ""
       o << word
-      o << '<a href="#wiki_extensins_fn_' +"#{data[:footnotes].length}" + '" class="wiki_extensions_fn" title="' + description + '" name="wiki_extensins_fn_src_' +"#{data[:footnotes].length}" + '">'
+      o << '<a href="#wiki_extensins_fn_' +"#{data[:footnotes].length}" + '" class="wiki_extensions_fn" title="' + h(description) + '" name="wiki_extensins_fn_src_' +"#{data[:footnotes].length}" + '">'
       o << "*#{data[:footnotes].length}"
       o << '</a>'
       return o.html_safe
@@ -60,7 +60,7 @@ module WikiExtensionsFootnote
       cnt = 0
       data[:footnotes].each {|fn|
         cnt += 1
-        o << '<li><span class="wiki_extensions_fn">'+ "*#{cnt}</span> " +'<a name="wiki_extensins_fn_' + "#{cnt}" + '" href="#wiki_extensins_fn_src_' + "#{cnt}" + '"' + ">#{fn['word']}</a>:#{fn['description']}</li>"
+        o << '<li><span class="wiki_extensions_fn">'+ "*#{cnt}</span> " +'<a name="wiki_extensins_fn_' + "#{cnt}" + '" href="#wiki_extensins_fn_src_' + "#{cnt}" + '"' + ">#{fn['word']}</a>:#{h fn['description']}</li>"
       }
       o << '</ul>'
       o << '</div>'


### PR DESCRIPTION
the footnote macro currently does not escape the description argument, which allows a malicious user to insert any javascript code into a page:

~~~
{{fn(word, <script>alert('foobar');</script>)}}
~~~