### PR TITLE
Skip Slack notifications when users don't need notifications in fork repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: codecov/codecov-action@v3
       - name: Slack Notification on Failure
         uses: rtCamp/action-slack-notify@v2.0.2
-        if: failure()
+        if: failure() && env.SLACK_WEBHOOK != ''
         env:
           SLACK_CHANNEL: plugin-wiki_ext
           SLACK_TITLE: Test Failure


### PR DESCRIPTION
How about considering the case which contributors don't use the Slack?