### PR TITLE
Use ApplicationRecord for Redmine 6 or later

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,6 @@
+# For backward compatibility with Redmine < 6.
+# ApplicationRecord is inherited from ActiveRecord Models instead of ActiveRecord::Base in Redmine >= 6.
+# ref: https://www.redmine.org/issues/38975
+unless defined?(ApplicationRecord)
+  ApplicationRecord = ActiveRecord::Base
+end

--- a/app/models/wiki_extensions_comment.rb
+++ b/app/models/wiki_extensions_comment.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsComment < ActiveRecord::Base
+class WikiExtensionsComment < ApplicationRecord
   belongs_to :user
   belongs_to :wiki_page
   validates_presence_of :comment, :wiki_page_id, :user_id

--- a/app/models/wiki_extensions_count.rb
+++ b/app/models/wiki_extensions_count.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsCount < ActiveRecord::Base
+class WikiExtensionsCount < ApplicationRecord
   belongs_to :project
   belongs_to :page, :foreign_key => :page_id, :class_name => 'WikiPage'
   validates_presence_of :project

--- a/app/models/wiki_extensions_menu.rb
+++ b/app/models/wiki_extensions_menu.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsMenu < ActiveRecord::Base
+class WikiExtensionsMenu < ApplicationRecord
   include Redmine::SafeAttributes
   belongs_to :project
   validates_presence_of :project_id

--- a/app/models/wiki_extensions_setting.rb
+++ b/app/models/wiki_extensions_setting.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsSetting < ActiveRecord::Base
+class WikiExtensionsSetting < ApplicationRecord
   belongs_to :project
   #attr_accessible :auto_preview_enabled, :tag_disabled
 

--- a/app/models/wiki_extensions_tag.rb
+++ b/app/models/wiki_extensions_tag.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsTag < ActiveRecord::Base
+class WikiExtensionsTag < ApplicationRecord
   #attr_accessible :name, :project_id
   validates_presence_of :name, :project_id
   validates_uniqueness_of :name, :scope => :project_id

--- a/app/models/wiki_extensions_tag_relation.rb
+++ b/app/models/wiki_extensions_tag_relation.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class WikiExtensionsTagRelation < ActiveRecord::Base
+class WikiExtensionsTagRelation < ApplicationRecord
   belongs_to :wiki_page
   belongs_to :tag, :class_name => 'WikiExtensionsTag', :foreign_key => :tag_id
   validates_presence_of :wiki_page_id, :tag_id

--- a/app/models/wiki_extensions_vote.rb
+++ b/app/models/wiki_extensions_vote.rb
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-class WikiExtensionsVote < ActiveRecord::Base
+class WikiExtensionsVote < ApplicationRecord
   validates_presence_of :target_class_name, :target_id, :keystr, :count
   validates_uniqueness_of :keystr, :scope => [:target_class_name, :target_id]
 


### PR DESCRIPTION
Please look at this PR first https://github.com/haru/redmine_wiki_extensions/pull/39.
After https://github.com/haru/redmine_wiki_extensions/pull/39, CI will be failed and then this PR will resolve it.

## Issue
CI failed because of the following error.
```console
/usr/local/bundle/gems/activerecord-7.1.2/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined method `acts_as_event' for WikiExtensionsComment:Class (NoMethodError)
```
ref: https://github.com/otegami/redmine_wiki_extensions/actions/runs/8228360886/job/22497676680

## Cause
`Redmine::Acts::Event` isn't included in `ActiveRecord::Base` anymore. That's the reason we cannot use `Redmine::Acts::Event#acts_as_event`.

Before Redmine v5.1, `ActiveRecord::Base` included `Redmine::Acts::Event`. And `ActiveRecord::Base` was a base class.

https://github.com/redmine/redmine/blob/ed7873a4c49d9209c597378dab9a982391093c32/lib/plugins/acts_as_event/init.rb#L4

After Redmine v6(master), `ApplicationRecord` includes `Redmine::Acts::Event`. And `ApplicationRecord` is a base class.

https://github.com/redmine/redmine/blob/fb449c77bc76b3bae9b3f0bfe18560b11f00902c/lib/plugins/acts_as_event/init.rb#L22

## Solution
Change the base class from ActiveRecord::Base to ApplicationRecord.