### PR TITLE
Fix CI: Redmine master doesn't support for Ruby v2,7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
         ruby_version: ["2.7", "3.0", "3.1", "3.2"]
         redmine_version: [4.2-stable, 5.0-stable, 5.1-stable, master]
         exclude:
+          - ruby_version: "2.7"
+            redmine_version: master
           - ruby_version: "3.0"
             redmine_version: 4.2-stable
           - ruby_version: "3.1"


### PR DESCRIPTION
## Issue
CI failed because of the following error.

```console
+ bundle install
Your Ruby version is 2.7.8, but your Gemfile specified >= 3.0.0, < 3.4.0
```
ref: https://github.com/otegami/redmine_wiki_extensions/actions/runs/8227000508/job/22494241147

## Cause
Redmine master(verison 6?) doesn't support for Ruby 2.7
- ref: https://github.com/redmine/redmine/blob/c3fe22476231adff5f6fef2e1692be8024dd0c44/Gemfile#L3

## Solutions
We can just exclude the Ruby version 2.7 matrix with Redmine master.