### PR TITLE
Adding view_wiki_pages permission to hide wiki links in project menu

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -64,7 +64,8 @@ Redmine::Plugin.register :redmine_wiki_extensions do
 
     menu :project_menu, menulist[i], { :controller => 'wiki_extensions', :action => 'forward_wiki_page', :menu_id => no }, :after => before,
                                                                                                                            :caption => Proc.new { |proj| WikiExtensionsMenu.title(proj.id, no) },
-                                                                                                                           :if => Proc.new { |proj| WikiExtensionsMenu.enabled?(proj.id, no) }
+                                                                                                                           :if => Proc.new { |proj| WikiExtensionsMenu.enabled?(proj.id, no) },
+                                                                                                                           :permission => :view_wiki_pages
   }
 
   RedCloth3::ALLOWED_TAGS << 'div'


### PR DESCRIPTION
Hello!

I've faced up with problem when user has not access to view wiki pages, but plugin show wiki pages in project menu. This fix apply corresponding permission