### PR TITLE
Update CI/dev environment for Redmine 7.0 and add create-pr skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,17 @@
       "Bash(python3 -c ' *)",
       "Bash(bundle list *)",
       "Bash(ls /usr/local/redmine/plugins/redmine_wiki_extensions/redmine_wiki_extensions/ 2>/dev/null | head -5 || echo \"does not exist\")",
-      "Read(//workspaces/redmine_wiki_extensions/**)"
+      "Read(//workspaces/redmine_wiki_extensions/**)",
+      "Bash(gh label *)",
+      "Bash(gh pr *)",
+      "Bash(git log *)",
+      "Bash(mkdir -p /usr/local/redmine/plugins/redmine_wiki_extensions/.claude/skills/create-pr/scripts)",
+      "Bash(mkdir -p /usr/local/redmine/plugins/redmine_wiki_extensions/.claude/skills/create-pr/evals)",
+      "Edit(/.claude/skills/create-pr/**)",
+      "Bash(chmod +x /usr/local/redmine/plugins/redmine_wiki_extensions/.claude/skills/create-pr/scripts/get_plugin_version.sh)",
+      "Bash(/usr/local/redmine/plugins/redmine_wiki_extensions/.claude/skills/create-pr/scripts/get_plugin_version.sh /usr/local/redmine/plugins/redmine_wiki_extensions/init.rb)",
+      "Bash(git fetch *)",
+      "Bash(.claude/skills/create-pr/scripts/get_plugin_version.sh init.rb)"
     ]
   },
   "enabledPlugins": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,5 +13,8 @@
       "Bash(ls /usr/local/redmine/plugins/redmine_wiki_extensions/redmine_wiki_extensions/ 2>/dev/null | head -5 || echo \"does not exist\")",
       "Read(//workspaces/redmine_wiki_extensions/**)"
     ]
+  },
+  "enabledPlugins": {
+    "skill-creator@claude-plugins-official": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,28 +1,6 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(yard stats *)",
-      "Bash(bundle exec *)",
-      "Bash(RAILS_ENV=test bundle exec rails runner ' *)",
-      "Bash(RAILS_ENV=test bundle exec rails runner \"puts ActiveRecord::Base.connection.execute\\(\\\\\"SELECT sql FROM sqlite_master WHERE tbl_name='wiki_pages' AND type='table'\\\\\"\\).first.inspect\")",
-      "Bash(RAILS_ENV=test bundle exec rake db:drop db:create db:migrate)",
-      "Bash(RAILS_ENV=test bundle exec rake db:migrate)",
-      "Bash(RAILS_ENV=test bundle exec rake redmine:plugins:migrate)",
-      "Bash(python3 -c ' *)",
-      "Bash(bundle list *)",
-      "Bash(ls /usr/local/redmine/plugins/redmine_wiki_extensions/redmine_wiki_extensions/ 2>/dev/null | head -5 || echo \"does not exist\")",
-      "Read(//workspaces/redmine_wiki_extensions/**)",
-      "Bash(gh label *)",
-      "Bash(gh pr *)",
-      "Bash(git log *)",
-      "Bash(mkdir -p /usr/local/redmine/plugins/redmine_wiki_extensions/.claude/skills/create-pr/scripts)",
-      "Bash(mkdir -p /usr/local/redmine/plugins/redmine_wiki_extensions/.claude/skills/create-pr/evals)",
-      "Edit(/.claude/skills/create-pr/**)",
-      "Bash(chmod +x /usr/local/redmine/plugins/redmine_wiki_extensions/.claude/skills/create-pr/scripts/get_plugin_version.sh)",
-      "Bash(/usr/local/redmine/plugins/redmine_wiki_extensions/.claude/skills/create-pr/scripts/get_plugin_version.sh /usr/local/redmine/plugins/redmine_wiki_extensions/init.rb)",
-      "Bash(git fetch *)",
-      "Bash(.claude/skills/create-pr/scripts/get_plugin_version.sh init.rb)"
-    ]
+    "allow": []
   },
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: create-pr
+description: Open a GitHub pull request for the current branch of this repository using the gh CLI, following this repo's branch conventions — release/* branches target main with a title/body of "Release <version>" (version read from init.rb), while every other branch targets develop with an auto-generated title, a bullet-point summary of the branch's changes, and an enhancement/bug/documentation label. Use this whenever the user asks to open, create, or submit a pull request or PR, says "gh pr create", or asks in Japanese to "PRを作って" / "プルリクを作成して" / "プルリクエストを出して".
+---
+
+# Create a pull request for this repo
+
+This repo has two very different PR shapes depending on the branch, and the
+right one only becomes obvious after you know which branch you're on. Work
+through the steps below in order — don't skip straight to `gh pr create`.
+
+## 1. Figure out the branch and its target
+
+```bash
+git branch --show-current
+```
+
+- Branch starts with `release/` → this is a **release PR**, target `main`.
+- Anything else → this is a **regular PR**, target `develop`.
+
+This distinction matters beyond just the `--base` flag: it changes where the
+title/body come from (steps 2 vs 3).
+
+Before drafting anything, sync so the diff you read is accurate:
+
+```bash
+git fetch origin main develop
+```
+
+## 2. Release PR (branch matches `release/*`)
+
+The release number is not the branch name — it's whatever `init.rb` actually
+declares as the plugin version, since that's the single source of truth the
+release process cuts a tag from. Read it with the bundled script rather than
+grepping ad hoc, since the `requires_redmine version_or_higher: ...` line
+sits right next to the real version and is easy to match by mistake:
+
+```bash
+.claude/skills/create-pr/scripts/get_plugin_version.sh init.rb
+```
+
+Use the result to build:
+- **Base**: `main`
+- **Title**: `Release <version>` (e.g. `Release 1.2.0`)
+- **Body**: same text as the title, `Release <version>`
+- **Labels**: none, unless the user asks for one
+
+Skip straight to step 4 (confirm) — there's no change summary or label
+classification to do for a release PR.
+
+## 3. Regular PR (any other branch)
+
+### Title and body from the actual diff
+
+Look at what the branch changed relative to `develop`, not just the commit
+messages (a branch may have messy WIP commits that don't reflect the final
+change):
+
+```bash
+git log origin/develop..HEAD --oneline
+git diff origin/develop...HEAD --stat
+```
+
+Read enough of the diff to understand the change, then write:
+- **Title**: a single imperative sentence describing the change, in the same
+  style as this repo's commit messages (verb + brief description, e.g. "Fix
+  compatibility with Redmine master", "Add view_wiki_pages permission").
+  Keep it under ~70 characters.
+- **Body**: a short bullet list of what changed, in English, e.g.:
+  ```
+  - Add X macro for embedding Y
+  - Update init.rb permissions to include Z
+  ```
+  Bullets should describe the *change*, not restate the diff line by line.
+
+### Choosing a label
+
+Classify the change by what it does to the codebase, not by keywords alone:
+
+- **enhancement** — adds or extends functionality (new macro, new setting,
+  new permission, new behavior).
+- **bug** — fixes incorrect behavior (something that used to misbehave now
+  doesn't).
+- **documentation** — only touches docs/comments (README, CLAUDE.md, YARD
+  comments) with no behavior change.
+
+If the branch mixes categories, pick the label matching its primary intent
+and mention the reasoning briefly when you confirm with the user.
+
+Not every change fits one of these three buckets — pure CI/tooling/dependency
+bumps (e.g. adding a Ruby or Redmine version to the test matrix) are neither
+a feature, a fix, nor documentation. Don't force a mismatched label onto
+those; leave the PR unlabeled instead. This matches how past PRs of that kind
+in this repo (e.g. #44, #45) were merged without a label.
+
+`documentation` doesn't exist as a label in every repo yet. Check first, and
+create it only if it's missing:
+
+```bash
+gh label list --json name -q '.[].name'
+# if "documentation" isn't in the list:
+gh label create documentation --color 0075ca --description "Improvements or additions to documentation"
+```
+
+Don't recreate `bug` or `enhancement` — they already exist in this repo with
+project-specific colors.
+
+## 4. Confirm before creating
+
+A PR is visible to other people the moment it's opened, so before running
+`gh pr create` show the user the drafted base/title/body/label and get a
+go-ahead — don't fire-and-forget one. This includes when the branch still
+needs a push:
+
+```bash
+git push -u origin "$(git branch --show-current)"   # only if not already pushed
+```
+
+## 5. Create the PR
+
+```bash
+gh pr create --base <main|develop> --title "<title>" --body "<body>" --label "<label>"
+```
+
+Omit `--label` entirely for release PRs. After it's created, report the PR
+URL back to the user.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pr
-description: Open a GitHub pull request for the current branch of this repository using the gh CLI, following this repo's branch conventions — release/* branches target main with a title/body of "Release <version>" (version read from init.rb), while every other branch targets develop with an auto-generated title, a bullet-point summary of the branch's changes, and an enhancement/bug/documentation label. Use this whenever the user asks to open, create, or submit a pull request or PR, says "gh pr create", or asks in Japanese to "PRを作って" / "プルリクを作成して" / "プルリクエストを出して".
+description: Open a GitHub pull request for the current branch of this repository using the gh CLI, following this repo's branch conventions — release/* branches target main with a title/body of "Release <version>" (version read from init.rb), while every other branch targets develop with an auto-generated title, a bullet-point summary of the branch's changes, and an enhancement/bug/documentation label where one fits (left unlabeled for pure CI/tooling changes). Use this whenever the user asks to open, create, or submit a pull request or PR, says "gh pr create", or asks in Japanese to "PRを作って" / "プルリクを作成して" / "プルリクエストを出して".
 ---
 
 # Create a pull request for this repo

--- a/.claude/skills/create-pr/scripts/get_plugin_version.sh
+++ b/.claude/skills/create-pr/scripts/get_plugin_version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Print the version declared in a Redmine plugin's init.rb (e.g. "1.2.0").
+# Usage: get_plugin_version.sh [path/to/init.rb]
+set -euo pipefail
+
+init_rb="${1:-init.rb}"
+
+version=$(sed -n "s/^[[:space:]]*version[[:space:]]*['\"]\\([^'\"]*\\)['\"].*/\\1/p" "$init_rb" | head -1)
+
+if [ -z "$version" ]; then
+  echo "Could not find a 'version \"x.y.z\"' line in $init_rb" >&2
+  exit 1
+fi
+
+echo "$version"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        # Update 'VARIANT' to pick a version of Ruby: 3, 3.1, 3.2, 3.3, 3.4
+        # Update 'VARIANT' to pick a version of Ruby: 3, 3.1, 3.2, 3.3, 3.4, 4.0
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
         RUBY_VERSION: "4.0"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,10 +9,10 @@ services:
         # Update 'VARIANT' to pick a version of Ruby: 3, 3.1, 3.2, 3.3, 3.4
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        RUBY_VERSION: "3.4"
+        RUBY_VERSION: "4.0"
         # Optional Node.js version to install
         NODE_VERSION: "lts/*"
-        REDMINE_VERSION: "6.1-stable"
+        REDMINE_VERSION: "7.0-stable"
     volumes:
       - ..:/usr/local/redmine/plugins/${PLUGIN_NAME:-dummy}
     # Overrides default command so things don't shut down after the process ends.
@@ -50,7 +50,7 @@ services:
       MYSQL_USER: redmine
       MYSQL_DB: redmine
       MYSQL_PASSWORD: remine
-  
+
 volumes:
   postgres-data: null
   mysql-data: null

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -44,6 +44,7 @@ fi
 bundle install 
 
 initdb() {
+    rm -f db/schema.rb
     bundle exec rake db:create
     bundle exec rake db:migrate
     bundle exec rake redmine:plugins:migrate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,19 @@ jobs:
     strategy:
       matrix:
         db: [sqlite3, mysql, postgres]
-        ruby_version: ["3.1", "3.2", "3.3", "3.4"]
-        redmine_version: [6.0-stable, 6.1-stable, master]
+        ruby_version: ["3.1", "3.2", "3.3", "3.4", "4.0"]
+        redmine_version: [6.0-stable, 6.1-stable, 7.0-stable, master]
         exclude:
           - ruby_version: "3.4"
             redmine_version: 6.0-stable
+          - ruby_version: "4.0"
+            redmine_version: 6.0-stable
           - ruby_version: "3.1"
             redmine_version: 6.1-stable
+          - ruby_version: "4.0"
+            redmine_version: 6.1-stable
+          - ruby_version: "3.1"
+            redmine_version: 7.0-stable
           - ruby_version: "3.1"
             redmine_version: master
     services:

--- a/.github/workflows/prevent-main-pr.yml
+++ b/.github/workflows/prevent-main-pr.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   prevent-main-pr:
+    if: ${{ !startsWith(github.event.pull_request.head.ref, 'release/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Comment and close PR

--- a/.github/workflows/prevent-main-pr.yml
+++ b/.github/workflows/prevent-main-pr.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   prevent-main-pr:
-    if: ${{ !startsWith(github.event.pull_request.head.ref, 'release/') }}
+    if: ${{ !(startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     steps:
       - name: Comment and close PR

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage
 Gemfile
 Gemfile.lock
 .yardoc/
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Gemfile
 Gemfile.lock
 .yardoc/
 tmp/
+.claude/settings.local.json


### PR DESCRIPTION
- Bump devcontainer and CI matrix to Ruby 4.0 and Redmine 7.0-stable
- Add exclusions for new incompatible version combos
- Fix prevent-main-pr workflow to allow PRs from release/* branches
- Reset db/schema.rb on devcontainer init to avoid stale schema
- Add create-pr skill for automating PR creation via gh CLI
- Ignore tmp/ directory